### PR TITLE
Fix ASM Transformer generating invalid frames

### DIFF
--- a/src/main/java/nilloader/api/NonLoadingClassWriter.java
+++ b/src/main/java/nilloader/api/NonLoadingClassWriter.java
@@ -3,9 +3,7 @@ package nilloader.api;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.objectweb.asm.ClassReader;
@@ -16,44 +14,73 @@ import org.objectweb.asm.tree.ClassNode;
 public class NonLoadingClassWriter extends ClassWriter {
 
 	private final Map<String, ClassNode> nodeCache = new HashMap<>();
-	
+
 	private final ClassLoader loader;
-	
+
 	public NonLoadingClassWriter(ClassLoader loader, int flags) {
 		super(flags);
 		this.loader = loader;
 	}
-	
+
 	@Override
 	protected ClassLoader getClassLoader() {
 		return loader;
 	}
-	
+
+	private boolean isImplementingInterface(ClassNode clazz, String interfaceName) {
+		if (clazz == null || clazz.name.equals("java/lang/Object")) {
+			return false;
+		}
+		for (String interfaces : clazz.interfaces) {
+			if (interfaces.equals(interfaceName)) {
+				return true;
+			} else {
+				if (isImplementingInterface(getClassNode(interfaces), interfaceName)) {
+					return true;
+				}
+			}
+		}
+		if ((clazz.access & Opcodes.ACC_INTERFACE) != 0) {
+			return false;
+		}
+		return isImplementingInterface(getClassNode(clazz.superName), interfaceName);
+	}
+
+	private boolean canAssign(ClassNode superType, ClassNode subType) {
+		if ((superType.access & Opcodes.ACC_INTERFACE) != 0) {
+			return isImplementingInterface(subType, superType.name);
+		} else {
+			while (subType != null) {
+				if (superType.name.equals(subType.name) || superType.name.equals(subType.superName)) {
+					return true;
+				}
+				if (subType.name.equals("java/lang/Object")) {
+					return false;
+				}
+				subType = getClassNode(subType.superName);
+			}
+		}
+		return false;
+	}
+
 	@Override
 	protected String getCommonSuperClass(String a, String b) {
 		if ("java/lang/Object".equals(a) || "java/lang/Object".equals(b)) return "java/lang/Object";
-		ClassNode an = getClassNode(a);
-		if ((an.access & Opcodes.ACC_INTERFACE) != 0 || an.superName == null) return "java/lang/Object";
-		ClassNode bn = getClassNode(b);
-		if ((bn.access & Opcodes.ACC_INTERFACE) != 0 || bn.superName == null) return "java/lang/Object";
-		if (an.superName.equals(bn.superName)) return an.superName;
-		if (an.superName.equals(b)) return b;
-		if (bn.superName.equals(a)) return a;
-		List<String> aSupers = walkSupers(an);
-		List<String> bSupers = walkSupers(bn);
-		for (String sup : aSupers) {
-			if (bSupers.contains(sup)) return sup;
+		ClassNode class1 = getClassNode(a);
+		ClassNode class2 = getClassNode(b);
+		if (class1 == null || class2 == null) {
+			return "java/lang/Object";
 		}
-		return "java/lang/Object";
-	}
-
-	private List<String> walkSupers(ClassNode node) {
-		List<String> out = new ArrayList<>();
-		while (node.superName != null) {
-			out.add(node.superName);
-			node = getClassNode(node.superName);
+		if (canAssign(class1, class2)) {
+			return class1.name;
 		}
-		return out;
+		if (canAssign(class2, class1)) {
+			return class2.name;
+		}
+		if (((class1.access | class2.access) & Opcodes.ACC_INTERFACE) != 0) {
+			return "java/lang/Object";
+		}
+		return getCommonSuperClass(a, class2.superName);
 	}
 
 	private ClassNode getClassNode(String type) {


### PR DESCRIPTION
I've been trying to integrate support for the [Micromixin](https://github.com/Starloader-project/Micromixin) framework (basically a reimplementation of sponge's Mixins I made for the sake of it) into NilLoader in order to test how javaagent-based mod loading would work and how reliable it is.

However I quickly noticed that many classes it touched weren't passing the Verifier due to invalid Frames. I am quite sure that the culprit is NilLoader's NonLoadingClassWriter not properly accounting for superinterfaces. Whatever the cause, changing the ClassWriter#getCommonSuperClass to a known-good implementation seems to have fixed the issue, but I am not too sure whether exclusively using ClassNodes is the right call as that could have some funny behaviour.

I also didn't test this in a minecraft setting, so I'd recommend to look at that before merging this PR in.

---

Note: This PR does not address issues caused by transforming classes located in the `java`, `com/sun`, `sun` and `jdk` packages (It might be beneficial to filter them out by default).